### PR TITLE
fix(icon): never draw an icon whose bitmap failed to load

### DIFF
--- a/app/components/HourlyChartView.svelte
+++ b/app/components/HourlyChartView.svelte
@@ -94,12 +94,15 @@
             return null;
         }
         const realIcon = iconService.getIconPath(iconId, isDay, false);
+        if (!realIcon) {
+            return null;
+        }
         let icon = iconCache[realIcon];
         if (icon) {
             return icon;
         }
         icon = loadImage(realIcon, { resizeThreshold: 80 });
-        if (!realIcon.startsWith('android.resource://')) {
+        if (icon && !realIcon.startsWith('android.resource://')) {
             iconCache[realIcon] = icon;
         }
         return icon;

--- a/app/components/compare/CompareWeatherIcons.svelte
+++ b/app/components/compare/CompareWeatherIcons.svelte
@@ -48,7 +48,7 @@
     let iconCache: { [k: string]: ImageSource } = {};
     function getIcon(iconId, isDay): ImageSource {
         const realIcon = iconService.getIconPath(iconId, isDay, false);
-        if (realIcon === null) {
+        if (!realIcon) {
             return null;
         }
         let icon = iconCache[realIcon];
@@ -56,7 +56,7 @@
             return icon;
         }
         icon = loadImage(realIcon, { resizeThreshold: 70 });
-        if (!realIcon.startsWith('android.resource://')) {
+        if (icon && !realIcon.startsWith('android.resource://')) {
             iconCache[realIcon] = icon;
         }
         return icon;

--- a/app/services/icon.ts
+++ b/app/services/icon.ts
@@ -2,87 +2,19 @@ import { ApplicationSettings, File, Folder, Observable, Utils, knownFolders, pat
 import { prefs } from './preferences';
 import { createGlobalEventListener, globalObservable } from '@shared/utils/svelte/ui';
 import { ANIMATIONS_ENABLED, PROVIDER_PADDING } from '~/helpers/constants';
+import { WEATHER_CODE_MAPPING, buildIconMap, resolveIconName } from './iconMapping';
 
 export const iconThemesFolder = path.join(knownFolders.currentApp().path, 'assets/icon_themes');
 export const onIconPackChanged = createGlobalEventListener('iconPack');
 export const onIconAnimationsChanged = createGlobalEventListener('iconAnimations');
 
-const WEATHER_CODE_MAPPING = new Map<number, number>();
-WEATHER_CODE_MAPPING.set(201, 200);
-WEATHER_CODE_MAPPING.set(202, 200);
-WEATHER_CODE_MAPPING.set(211, 210);
-WEATHER_CODE_MAPPING.set(212, 211);
-WEATHER_CODE_MAPPING.set(221, 212);
-WEATHER_CODE_MAPPING.set(230, 200);
-WEATHER_CODE_MAPPING.set(231, 201);
-WEATHER_CODE_MAPPING.set(232, 202);
-
-WEATHER_CODE_MAPPING.set(300, 500);
-WEATHER_CODE_MAPPING.set(301, 300);
-WEATHER_CODE_MAPPING.set(302, 300);
-WEATHER_CODE_MAPPING.set(310, 300);
-WEATHER_CODE_MAPPING.set(311, 310);
-WEATHER_CODE_MAPPING.set(312, 311);
-WEATHER_CODE_MAPPING.set(313, 313);
-WEATHER_CODE_MAPPING.set(314, 313);
-WEATHER_CODE_MAPPING.set(321, 301);
-
-WEATHER_CODE_MAPPING.set(501, 500);
-WEATHER_CODE_MAPPING.set(502, 501);
-WEATHER_CODE_MAPPING.set(503, 502);
-WEATHER_CODE_MAPPING.set(504, 503);
-WEATHER_CODE_MAPPING.set(510, 500);
-WEATHER_CODE_MAPPING.set(511, 501);
-WEATHER_CODE_MAPPING.set(520, 500);
-WEATHER_CODE_MAPPING.set(521, 501);
-WEATHER_CODE_MAPPING.set(522, 503);
-WEATHER_CODE_MAPPING.set(531, 503);
-
-WEATHER_CODE_MAPPING.set(601, 600);
-WEATHER_CODE_MAPPING.set(602, 601);
-WEATHER_CODE_MAPPING.set(603, 602);
-WEATHER_CODE_MAPPING.set(611, 601);
-WEATHER_CODE_MAPPING.set(612, 600);
-WEATHER_CODE_MAPPING.set(613, 601);
-WEATHER_CODE_MAPPING.set(615, 600);
-WEATHER_CODE_MAPPING.set(616, 601);
-WEATHER_CODE_MAPPING.set(620, 600);
-WEATHER_CODE_MAPPING.set(621, 601);
-WEATHER_CODE_MAPPING.set(622, 602);
-
-WEATHER_CODE_MAPPING.set(711, 701);
-WEATHER_CODE_MAPPING.set(721, 701);
-WEATHER_CODE_MAPPING.set(731, 701);
-WEATHER_CODE_MAPPING.set(741, 701);
-WEATHER_CODE_MAPPING.set(751, 731);
-WEATHER_CODE_MAPPING.set(761, 731);
-WEATHER_CODE_MAPPING.set(762, 731);
-WEATHER_CODE_MAPPING.set(771, 701);
-WEATHER_CODE_MAPPING.set(781, 771);
-
-WEATHER_CODE_MAPPING.set(801, 800);
-WEATHER_CODE_MAPPING.set(802, 801);
-WEATHER_CODE_MAPPING.set(803, 802);
-WEATHER_CODE_MAPPING.set(804, 803);
-
 function fillIconMap(folderPath: string, map: Map<number, number>) {
-    map.clear();
-    Folder.fromPath(folderPath)
-        .getEntitiesSync()
-        .map((e) => e.name)
-        .reduce((acc, current) => {
-            current = current.split('.').slice(0, -1).join('.');
-            const length = current.length;
-            if (length === 3) {
-                acc.set(parseInt(current, 10), 0);
-            } else {
-                const id = parseInt(current.slice(0, -1), 10);
-                if (!acc.has(id)) {
-                    acc.set(id, 1);
-                }
-            }
-            return acc;
-        }, map);
+    buildIconMap(
+        Folder.fromPath(folderPath)
+            .getEntitiesSync()
+            .map((e) => e.name),
+        map
+    );
 }
 export class IconService extends Observable {
     getIconConfig(folderPath = this.iconSetFolderPath) {
@@ -171,6 +103,10 @@ export class IconService extends Observable {
         } else {
             const iconSetFolderPath = path.join(iconThemesFolder, iconSet || iconService.iconSet);
             const realIcon = iconService.getIcon(iconId, isDay, false);
+            if (!realIcon) {
+                // no icon of that pack can represent that id: better no icon than a path to a missing file
+                return null;
+            }
             if (animated) {
                 return `~/assets/icon_themes/${iconSet}/lottie/${realIcon}.lottie`;
             } else {
@@ -187,17 +123,10 @@ export class IconService extends Observable {
         if (cached) {
             return cached;
         }
-        const mapIds = animated ? this.lotties : this.images;
-        let realIconId = iconId;
-        let mapId = mapIds.get(realIconId);
-        while (mapId === undefined && realIconId !== undefined) {
-            realIconId = WEATHER_CODE_MAPPING.get(realIconId);
-            mapId = mapIds.get(realIconId);
-        }
-        if (!realIconId) {
+        const result = resolveIconName(iconId, isDay, animated ? this.lotties : this.images);
+        if (result === null) {
             return null;
         }
-        const result = `${realIconId}${mapId === 1 ? (isDay ? 'd' : 'n') : ''}`;
         this.mappingCache.set(key, result);
         return result;
     }

--- a/app/services/iconMapping.test.ts
+++ b/app/services/iconMapping.test.ts
@@ -1,0 +1,43 @@
+import { readdirSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+import { buildIconMap, resolveIconName } from './iconMapping';
+import { convertWeatherCodeToIcon } from './providers/omIcons';
+
+const ICON_THEMES_FOLDER = join(__dirname, '../assets/icon_themes');
+
+function iconMapForPack(pack: string) {
+    return buildIconMap(readdirSync(join(ICON_THEMES_FOLDER, pack, 'images')), new Map<number, number>());
+}
+
+const PACKS = readdirSync(ICON_THEMES_FOLDER);
+
+describe('resolveIconName', () => {
+    it('resolves an id the pack has, with its day/night variant', () => {
+        const mapIds = iconMapForPack('meteocons');
+        expect(resolveIconName(800, true, mapIds)).toBe('800d');
+        expect(resolveIconName(800, false, mapIds)).toBe('800n');
+        expect(resolveIconName(701, true, mapIds)).toBe('701');
+    });
+
+    it('walks the mapping chain for an id the pack lacks', () => {
+        expect(resolveIconName(804, true, iconMapForPack('weathericons'))).toBe('802d');
+    });
+
+    it('resolves 530, still present in cached data of older versions', () => {
+        expect(resolveIconName(530, true, iconMapForPack('meteocons'))).toBe('520');
+        expect(resolveIconName(530, true, iconMapForPack('weathericons'))).toBe('500d');
+    });
+
+    it('returns null for an unknown id', () => {
+        expect(resolveIconName(9999, true, iconMapForPack('meteocons'))).toBeNull();
+    });
+
+    it.each(PACKS)('resolves every icon id OpenMeteo can produce (%s)', (pack) => {
+        const mapIds = iconMapForPack(pack);
+        // WMO codes as documented by OpenMeteo
+        const iconIds = Array.from({ length: 100 }, (_, code) => convertWeatherCodeToIcon(code)).filter((iconId) => iconId !== undefined);
+        const unresolved = iconIds.filter((iconId) => resolveIconName(iconId, true, mapIds) === null);
+        expect(unresolved).toEqual([]);
+    });
+});

--- a/app/services/iconMapping.ts
+++ b/app/services/iconMapping.ts
@@ -1,0 +1,101 @@
+export const WEATHER_CODE_MAPPING = new Map<number, number>();
+WEATHER_CODE_MAPPING.set(201, 200);
+WEATHER_CODE_MAPPING.set(202, 200);
+WEATHER_CODE_MAPPING.set(211, 210);
+WEATHER_CODE_MAPPING.set(212, 211);
+WEATHER_CODE_MAPPING.set(221, 212);
+WEATHER_CODE_MAPPING.set(230, 200);
+WEATHER_CODE_MAPPING.set(231, 201);
+WEATHER_CODE_MAPPING.set(232, 202);
+
+WEATHER_CODE_MAPPING.set(300, 500);
+WEATHER_CODE_MAPPING.set(301, 300);
+WEATHER_CODE_MAPPING.set(302, 300);
+WEATHER_CODE_MAPPING.set(310, 300);
+WEATHER_CODE_MAPPING.set(311, 310);
+WEATHER_CODE_MAPPING.set(312, 311);
+WEATHER_CODE_MAPPING.set(313, 313);
+WEATHER_CODE_MAPPING.set(314, 313);
+WEATHER_CODE_MAPPING.set(321, 301);
+
+WEATHER_CODE_MAPPING.set(501, 500);
+WEATHER_CODE_MAPPING.set(502, 501);
+WEATHER_CODE_MAPPING.set(503, 502);
+WEATHER_CODE_MAPPING.set(504, 503);
+WEATHER_CODE_MAPPING.set(510, 500);
+WEATHER_CODE_MAPPING.set(511, 501);
+WEATHER_CODE_MAPPING.set(520, 500);
+WEATHER_CODE_MAPPING.set(521, 501);
+WEATHER_CODE_MAPPING.set(522, 503);
+// 530 is not an OWM code: it was produced by older versions for OpenMeteo code 82 and can still sit in cached data
+WEATHER_CODE_MAPPING.set(530, 520);
+WEATHER_CODE_MAPPING.set(531, 503);
+
+WEATHER_CODE_MAPPING.set(601, 600);
+WEATHER_CODE_MAPPING.set(602, 601);
+WEATHER_CODE_MAPPING.set(603, 602);
+WEATHER_CODE_MAPPING.set(611, 601);
+WEATHER_CODE_MAPPING.set(612, 600);
+WEATHER_CODE_MAPPING.set(613, 601);
+WEATHER_CODE_MAPPING.set(615, 600);
+WEATHER_CODE_MAPPING.set(616, 601);
+WEATHER_CODE_MAPPING.set(620, 600);
+WEATHER_CODE_MAPPING.set(621, 601);
+WEATHER_CODE_MAPPING.set(622, 602);
+
+WEATHER_CODE_MAPPING.set(711, 701);
+WEATHER_CODE_MAPPING.set(721, 701);
+WEATHER_CODE_MAPPING.set(731, 701);
+WEATHER_CODE_MAPPING.set(741, 701);
+WEATHER_CODE_MAPPING.set(751, 731);
+WEATHER_CODE_MAPPING.set(761, 731);
+WEATHER_CODE_MAPPING.set(762, 731);
+WEATHER_CODE_MAPPING.set(771, 701);
+WEATHER_CODE_MAPPING.set(781, 771);
+
+WEATHER_CODE_MAPPING.set(801, 800);
+WEATHER_CODE_MAPPING.set(802, 801);
+WEATHER_CODE_MAPPING.set(803, 802);
+WEATHER_CODE_MAPPING.set(804, 803);
+
+/**
+ * Builds the icon id map from icon file names ('800d.png', '701.png'):
+ * icon id => 1 when the pack has day/night variants, 0 when it has a single file.
+ */
+export function buildIconMap(fileNames: string[], map: Map<number, number>) {
+    map.clear();
+    return fileNames.reduce((acc, current) => {
+        current = current.split('.').slice(0, -1).join('.');
+        const length = current.length;
+        if (length === 3) {
+            acc.set(parseInt(current, 10), 0);
+        } else {
+            const id = parseInt(current.slice(0, -1), 10);
+            if (!acc.has(id)) {
+                acc.set(id, 1);
+            }
+        }
+        return acc;
+    }, map);
+}
+
+/**
+ * Resolves a weather icon id to the name of an icon actually present in the pack,
+ * walking WEATHER_CODE_MAPPING until a match is found.
+ * Returns null when no icon of that pack can represent the id.
+ */
+export function resolveIconName(iconId: number, isDay: boolean, mapIds: Map<number, number>) {
+    if (!iconId && iconId !== 0) {
+        return null;
+    }
+    let realIconId = iconId;
+    let mapId = mapIds.get(realIconId);
+    while (mapId === undefined && realIconId !== undefined) {
+        realIconId = WEATHER_CODE_MAPPING.get(realIconId);
+        mapId = mapIds.get(realIconId);
+    }
+    if (!realIconId) {
+        return null;
+    }
+    return `${realIconId}${mapId === 1 ? (isDay ? 'd' : 'n') : ''}`;
+}

--- a/app/services/providers/om.ts
+++ b/app/services/providers/om.ts
@@ -6,6 +6,7 @@ import { Pollutants, prepareAirQualityData } from '../airQualityData';
 import { WeatherLocation, request } from '../api';
 import { WeatherProps, weatherDataService } from '../weatherData';
 import { AirQualityProvider } from './airqualityprovider';
+import { convertWeatherCodeToIcon } from './omIcons';
 import { Forecast } from './openmeteo';
 import { AirQualityCurrently, AirQualityData, CommonAirQualityData, Currently, DailyData, Hourly, MinutelyData, WeatherData } from './weather';
 import { WeatherProvider } from './weatherprovider';
@@ -238,61 +239,6 @@ export class OMProvider extends WeatherProvider implements AirQualityProvider {
         }
     }
 
-    private convertWeatherCodeToIcon(code: number) {
-        // const actualCode = code % 100;
-        switch (code) {
-            case 0:
-            case 1:
-                return 800;
-            case 2:
-                return 802;
-            case 3:
-                return 804;
-            case 45:
-            case 48:
-                return 741;
-            case 51:
-            case 56:
-                return 300;
-            case 53:
-            case 57:
-                return 310;
-            case 55:
-                return 321;
-            case 61:
-                return 500;
-            case 63:
-            case 66:
-                return 502;
-            case 65:
-            case 67:
-                return 504;
-            case 80:
-            case 81:
-                return 520;
-            case 82:
-                return 530;
-
-            case 71:
-                return 600;
-            case 73:
-            case 85:
-                return 601;
-            case 75:
-            case 86:
-                return 602;
-            case 77:
-                return 611;
-            case 95:
-                return 200;
-            case 96:
-                return 210;
-            case 97:
-            case 99:
-                return 202;
-        }
-    }
-
     // https://api.open-meteo.com/v1/forecast?latitude=45.18&longitude=5.71&hourly=temperature_2m,apparent_temperature,precipitation_probability,precipitation,rain,showers,snowfall,snow_depth,weathercode,cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,windspeed_10m,winddirection_10m,windgusts_10m,uv_index,uv_index_clear_sky&models=best_match&daily=weathercode,temperature_2m_max,temperature_2m_min,apparent_temperature_max,apparent_temperature_min,uv_index_max,uv_index_clear_sky_max,precipitation_sum,rain_sum,showers_sum,snowfall_sum,precipitation_hours,precipitation_probability_max,windspeed_10m_max,windgusts_10m_max,winddirection_10m_dominant&timeformat=unixtime&forecast_days=14&timezone=auto
     private async fetch<T = any>(
         apiName: string = 'forecast',
@@ -392,7 +338,7 @@ export class OMProvider extends WeatherProvider implements AirQualityProvider {
             d.time = time * 1000;
             const code = hourly_weathercodes[index];
             d.isDay = !!this.getDataArrayValue(hourly, 'is_day', model, index);
-            d.iconId = this.convertWeatherCodeToIcon(code);
+            d.iconId = convertWeatherCodeToIcon(code);
             d.description = OMProvider.getWeatherCodeDescription(code);
             const apparentTemperature = this.getDataArrayValue(hourly, 'apparent_temperature', model, index);
             if (apparentTemperature !== undefined) {
@@ -501,7 +447,7 @@ export class OMProvider extends WeatherProvider implements AirQualityProvider {
                           cloudCover: currentData.cloudcover,
                           isDay: !!currentData.is_day,
                           windBearing: currentData.winddirection_10m,
-                          iconId: this.convertWeatherCodeToIcon(currentData.weather_code),
+                          iconId: convertWeatherCodeToIcon(currentData.weather_code),
                           description: OMProvider.getWeatherCodeDescription(currentData.weather_code)
                       } as Currently,
                       WeatherDataType.CURRENT,
@@ -515,7 +461,7 @@ export class OMProvider extends WeatherProvider implements AirQualityProvider {
                         time: time * 1000,
                         description: OMProvider.getWeatherCodeDescription(code),
                         isDay: true,
-                        iconId: this.convertWeatherCodeToIcon(code),
+                        iconId: convertWeatherCodeToIcon(code),
                         apparentTemperatureMax: this.getDataArrayValue(daily, 'apparent_temperature_max', model, index),
                         apparentTemperatureMin: this.getDataArrayValue(daily, 'apparent_temperature_min', model, index),
                         temperatureMax: this.getDataArrayValue(daily, feelsLikeTemperatures ? 'apparent_temperature_max' : 'temperature_2m_max', model, index),

--- a/app/services/providers/omIcons.ts
+++ b/app/services/providers/omIcons.ts
@@ -1,0 +1,57 @@
+/**
+ * Converts an OpenMeteo (WMO) weather code to the OWM icon id space used across the app.
+ * Returns undefined for codes we have no icon for.
+ */
+export function convertWeatherCodeToIcon(code: number) {
+    switch (code) {
+        case 0:
+        case 1:
+            return 800;
+        case 2:
+            return 802;
+        case 3:
+            return 804;
+        case 45:
+        case 48:
+            return 741;
+        case 51:
+        case 56:
+            return 300;
+        case 53:
+        case 57:
+            return 310;
+        case 55:
+            return 321;
+        case 61:
+            return 500;
+        case 63:
+        case 66:
+            return 502;
+        case 65:
+        case 67:
+            return 504;
+        case 80:
+        case 81:
+            return 520;
+        case 82:
+            return 522;
+
+        case 71:
+            return 600;
+        case 73:
+        case 85:
+            return 601;
+        case 75:
+        case 86:
+            return 602;
+        case 77:
+            return 611;
+        case 95:
+            return 200;
+        case 96:
+            return 210;
+        case 97:
+        case 99:
+            return 202;
+    }
+}

--- a/app/utils/utils.common.ts
+++ b/app/utils/utils.common.ts
@@ -10,7 +10,10 @@ export { restartApp } from '@akylas/nativescript-app-utils';
 export const sdkVersion = parseInt(Device.sdkVersion, 10);
 
 export function loadImage(imagePath, options) {
-    if (imagePath?.startsWith('android.resource://')) {
+    if (!imagePath) {
+        return null;
+    }
+    if (imagePath.startsWith('android.resource://')) {
         //@ts-expect-error needs ui-image typings
         const drawable = com.nativescript.image.DrawableUtils.tryLoadExternalDrawable(
             Utils.android.getApplicationContext(),
@@ -18,7 +21,10 @@ export function loadImage(imagePath, options) {
         ) as android.graphics.drawable.BitmapDrawable;
         return drawable ? new ImageSource(drawable.getBitmap()) : null;
     }
-    return loadImageSync(imagePath, options);
+    const image = loadImageSync(imagePath, options);
+    // loadImageSync always returns an ImageSource, even when decoding failed. Such an ImageSource is truthy
+    // but drawing it (canvas.drawBitmap) crashes the app with a native NPE
+    return (__ANDROID__ ? image?.android : image?.ios) ? image : null;
 }
 
 declare module '@nativescript/core/ui/frame' {


### PR DESCRIPTION
## Summary

Crash loop reported in #504: `NullPointerException: Attempt to invoke virtual method 'boolean android.graphics.Bitmap.isRecycled()' on a null object reference` thrown from `onDraw`, every frame, so the main page could not be drawn at all any more.

Chain: OpenMeteo code 82 was converted to iconId `530`, an id no icon pack contains and `WEATHER_CODE_MAPPING` does not map. `getIconPath` did not check that the resolution failed and built a path to a missing `.../images/null.png`; `loadImageSync` wraps its result in an `ImageSource` unconditionally, so a failed decode yields a *truthy* `ImageSource` with a null bitmap that passes every `if (icon)` guard; `canvas.drawBitmap` then hands `null` to the native canvas.

- convert OpenMeteo code 82 to `522` (the OWM code for heavy shower rain), and map `530 -> 520` so weather data already cached with the bad id renders instead of crashing
- `getIconPath` returns `null` when no icon of the pack can represent the id, instead of interpolating `null` into a file path
- `loadImage` returns `null` when the underlying bitmap failed to load — the single choke point that also covers a corrupt pack file or a stale icon-provider drawable path
- extract the icon id resolution (`app/services/iconMapping.ts`) and the OpenMeteo code conversion (`app/services/providers/omIcons.ts`) into pure modules, so the mapping can be unit tested

## Testing

`npx vitest run` — 39 passing, including a new `app/services/iconMapping.test.ts` that walks **every** icon id the OpenMeteo converter can produce against **every** bundled icon pack. That test fails on `main` with `expected [ 530 ] to deeply equal []`, and is the regression net that would have caught this.

`yarn svelte-check` clean (only a pre-existing error in the `tools` submodule).

Not run on device — a visual check on Android is still required: hourly chart and the model comparison view still draw their icons, and an unresolvable icon leaves a gap instead of crashing.

Fixes #504